### PR TITLE
Update code_of_conduct.md

### DIFF
--- a/about/code_of_conduct.md
+++ b/about/code_of_conduct.md
@@ -24,7 +24,7 @@ Examples of unacceptable behaviour by participants include:
 
 * The use of sexualised language or imagery and unwelcome sexual attention or
 advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* Trolling, insulting/derogatory comments, and personal attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic
   address, without explicit permission


### PR DESCRIPTION
Suggest removing "political attacks" from the examples of unacceptable behaviour as it is ambiguous.  Political attacks in the sense of dispassionate attack of political views should be acceptable as part of healthy debate.  By contrast, the use of politics as an excuse or pretext for a personal attack is entirely unacceptable, but the other examples already make that clear.